### PR TITLE
fix refmap for mixinextra injection types not generated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,8 +100,8 @@ dependencies {
     repackMixinSources("org.ow2.asm:asm-util:$asmVersion:sources")
     repackMixinSources("com.google.guava:guava:21.0:sources")
 
-    repackMixinProcessor("org.spongepowered:mixin:$mixinVersion:processor")
     repackMixinProcessor("com.github.LlamaLad7:MixinExtras:$mixinExtrasVersion")
+    repackMixinProcessor("org.spongepowered:mixin:$mixinVersion:processor")
 
     implementation name: "mixin-$mixinVersion-repack"
     annotationProcessor name: "mixin-$mixinVersion-processor-repack"

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'forge'
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-version = "2.1.1"
+version = "2.1.2"
 group = "com.gtnewhorizon" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "gtnhmixins"
 


### PR DESCRIPTION
To quote mixin extra

> It is essential that you register MixinExtras as an annotation processor if you want remapping of custom features to work. If you are registering Mixin as an annotation processor too, you must register the MixinExtras annotation processor before the Mixin one.

This PR reorders mixinextra before sponge and magically (*) it will init mixinextra apt before sponge mixin apt is initialized.

*: This depends on a series of coincidence
* [mergeServiceFiles uses a groovy map](https://github.com/johnrengelman/shadow/blob/d8117e942b7d98e3274cb1cc9dbb4e4e978a2a58/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy#L54), which is actually [LinkedHashMap](https://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/Map.html#drop(int)), which preserves insertion order when iterated.
* dependencies are walked in insertion order to merge/relocate/shadow/whatever you call that step.
* ServiceLoader process *usually* each service definition files in a classloader defined order (which is *usually* the order they exist on classpath, but this doesn't matter here), but within each file it *usually* process it from start to end.
  * Here I said usually, because this is not required in specification, but this is the most straightfoward way of implementing it, and openjdk and most of its derivates do it.